### PR TITLE
Bump the max supported glam version up to 0.20

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ categories = ["game-development"]
 readme = "crates-io.md"
 
 [dependencies]
-glam = ">=0.15, <=0.18"
+glam = ">=0.15, <=0.20"
 
 [dev-dependencies]
 macroquad = "0.3"


### PR DESCRIPTION
None of the [breaking changes](https://github.com/bitshifter/glam-rs/blob/main/CHANGELOG.md) in `0.19` or `0.20` seem to be a problem for the crate.