### PR TITLE
🐑 Left-handed systems support.

### DIFF
--- a/examples/nested_driver.rs
+++ b/examples/nested_driver.rs
@@ -5,16 +5,16 @@ use macroquad::prelude::*;
 
 /// A custom camera rig which combines smoothed movement with a look-at driver.
 #[derive(Debug)]
-pub struct MovableLookAt<H: Handedness + 'static>(CameraRig<H>);
+pub struct MovableLookAt<H: Handedness>(CameraRig<H>);
 
 // Turn the nested rig into a driver, so it can be used in another rig.
-impl<H: Handedness + 'static> RigDriver<H> for MovableLookAt<H> {
+impl<H: Handedness> RigDriver<H> for MovableLookAt<H> {
     fn update(&mut self, params: dolly::rig::RigUpdateParams<H>) -> dolly::transform::Transform<H> {
         self.0.update(params.delta_time_seconds)
     }
 }
 
-impl<H: Handedness + 'static> MovableLookAt<H> {
+impl<H: Handedness> MovableLookAt<H> {
     pub fn from_position_target(
         camera_position: dolly::glam::Vec3,
         target_position: dolly::glam::Vec3,

--- a/examples/nested_driver.rs
+++ b/examples/nested_driver.rs
@@ -94,7 +94,7 @@ async fn main() {
         set_camera(&Camera3D {
             position: camera_xform.position.d2m(),
             up: camera_xform.up().d2m(),
-            target: (camera_xform.position + camera_xform.forward()).d2m(),
+            target: (camera_xform.position + camera_xform.forward(camera.is_right_handed())).d2m(),
             ..Default::default()
         });
 

--- a/examples/nested_driver.rs
+++ b/examples/nested_driver.rs
@@ -5,16 +5,16 @@ use macroquad::prelude::*;
 
 /// A custom camera rig which combines smoothed movement with a look-at driver.
 #[derive(Debug)]
-pub struct MovableLookAt(CameraRig);
+pub struct MovableLookAt<H: Handedness + 'static>(CameraRig<H>);
 
 // Turn the nested rig into a driver, so it can be used in another rig.
-impl RigDriver for MovableLookAt {
-    fn update(&mut self, params: dolly::rig::RigUpdateParams) -> dolly::transform::Transform {
+impl<H: Handedness + 'static> RigDriver<H> for MovableLookAt<H> {
+    fn update(&mut self, params: dolly::rig::RigUpdateParams<H>) -> dolly::transform::Transform<H> {
         self.0.update(params.delta_time_seconds)
     }
 }
 
-impl MovableLookAt {
+impl<H: Handedness + 'static> MovableLookAt<H> {
     pub fn from_position_target(
         camera_position: dolly::glam::Vec3,
         target_position: dolly::glam::Vec3,
@@ -81,7 +81,7 @@ async fn main() {
 
         // Update the camera driver
         camera
-            .driver_mut::<MovableLookAt>()
+            .driver_mut::<MovableLookAt<RightHanded>>()
             .set_position_target(camera_position, player_position);
 
         // Update the camera rig, and get the interpolated transform
@@ -94,7 +94,7 @@ async fn main() {
         set_camera(&Camera3D {
             position: camera_xform.position.d2m(),
             up: camera_xform.up().d2m(),
-            target: (camera_xform.position + camera_xform.forward(camera.is_right_handed())).d2m(),
+            target: (camera_xform.position + camera_xform.forward()).d2m(),
             ..Default::default()
         });
 

--- a/examples/orbit.rs
+++ b/examples/orbit.rs
@@ -6,7 +6,7 @@ use macroquad::prelude::*;
 #[macroquad::main("dolly orbit example")]
 async fn main() {
     // Create a smoothed orbit camera
-    let mut camera = CameraRig::builder()
+    let mut camera = CameraRig::<RightHanded>::builder()
         .with(YawPitch::new().yaw_degrees(45.0).pitch_degrees(-30.0))
         .with(Smooth::new_rotation(1.5))
         .with(Arm::new(dolly::glam::Vec3::Z * 8.0))
@@ -31,10 +31,7 @@ async fn main() {
         set_camera(&Camera3D {
             position: <[f32; 3]>::from(camera_xform.position).into(),
             up: <[f32; 3]>::from(camera_xform.up()).into(),
-            target: <[f32; 3]>::from(
-                camera_xform.position + camera_xform.forward(camera.is_right_handed()),
-            )
-            .into(),
+            target: <[f32; 3]>::from(camera_xform.position + camera_xform.forward()).into(),
             ..Default::default()
         });
 

--- a/examples/orbit.rs
+++ b/examples/orbit.rs
@@ -6,7 +6,7 @@ use macroquad::prelude::*;
 #[macroquad::main("dolly orbit example")]
 async fn main() {
     // Create a smoothed orbit camera
-    let mut camera = CameraRig::<RightHanded>::builder()
+    let mut camera: CameraRig = CameraRig::builder()
         .with(YawPitch::new().yaw_degrees(45.0).pitch_degrees(-30.0))
         .with(Smooth::new_rotation(1.5))
         .with(Arm::new(dolly::glam::Vec3::Z * 8.0))

--- a/examples/orbit.rs
+++ b/examples/orbit.rs
@@ -31,7 +31,10 @@ async fn main() {
         set_camera(&Camera3D {
             position: <[f32; 3]>::from(camera_xform.position).into(),
             up: <[f32; 3]>::from(camera_xform.up()).into(),
-            target: <[f32; 3]>::from(camera_xform.position + camera_xform.forward()).into(),
+            target: <[f32; 3]>::from(
+                camera_xform.position + camera_xform.forward(camera.is_right_handed()),
+            )
+            .into(),
             ..Default::default()
         });
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,19 +1,21 @@
-use crate::{rig::RigUpdateParams, transform::Transform};
+use crate::{handedness::Handedness, rig::RigUpdateParams, transform::Transform};
 
-pub trait RigDriverTraits: RigDriver + Sync + Send + std::any::Any + std::fmt::Debug {
+pub trait RigDriverTraits<H: Handedness + 'static>:
+    RigDriver<H> + Sync + Send + std::any::Any + std::fmt::Debug
+{
     /// Returns `self` as `&mut dyn Any`
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
-pub trait RigDriver: std::any::Any + std::fmt::Debug {
+pub trait RigDriver<H: Handedness + 'static>: std::any::Any + std::fmt::Debug {
     /// Calculates the transform of this driver component based on the parent
     /// provided in `params`.
-    fn update(&mut self, params: RigUpdateParams) -> Transform;
+    fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H>;
 }
 
-impl<T> RigDriverTraits for T
+impl<H: Handedness + 'static, T> RigDriverTraits<H> for T
 where
-    T: RigDriver + std::any::Any + Sync + Send + std::fmt::Debug,
+    T: RigDriver<H> + std::any::Any + Sync + Send + std::fmt::Debug,
 {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
         self

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -1,19 +1,19 @@
 use crate::{handedness::Handedness, rig::RigUpdateParams, transform::Transform};
 
-pub trait RigDriverTraits<H: Handedness + 'static>:
+pub trait RigDriverTraits<H: Handedness>:
     RigDriver<H> + Sync + Send + std::any::Any + std::fmt::Debug
 {
     /// Returns `self` as `&mut dyn Any`
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
-pub trait RigDriver<H: Handedness + 'static>: std::any::Any + std::fmt::Debug {
+pub trait RigDriver<H: Handedness>: std::any::Any + std::fmt::Debug {
     /// Calculates the transform of this driver component based on the parent
     /// provided in `params`.
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H>;
 }
 
-impl<H: Handedness + 'static, T> RigDriverTraits<H> for T
+impl<H: Handedness, T> RigDriverTraits<H> for T
 where
     T: RigDriver<H> + std::any::Any + Sync + Send + std::fmt::Debug,
 {

--- a/src/drivers/arm.rs
+++ b/src/drivers/arm.rs
@@ -25,7 +25,7 @@ impl<H: Handedness> RigDriver<H> for Arm {
         Transform {
             rotation: params.parent.rotation,
             position: params.parent.position + params.parent.rotation * self.offset,
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/drivers/arm.rs
+++ b/src/drivers/arm.rs
@@ -20,7 +20,7 @@ impl Arm {
     }
 }
 
-impl<H: Handedness + 'static> RigDriver<H> for Arm {
+impl<H: Handedness> RigDriver<H> for Arm {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             rotation: params.parent.rotation,

--- a/src/drivers/arm.rs
+++ b/src/drivers/arm.rs
@@ -1,6 +1,10 @@
+use std::marker::PhantomData;
+
 use glam::Vec3;
 
-use crate::{driver::RigDriver, rig::RigUpdateParams, transform::Transform};
+use crate::{
+    driver::RigDriver, handedness::Handedness, rig::RigUpdateParams, transform::Transform,
+};
 
 /// Offsets the camera along a vector, in the coordinate space of the parent.
 #[derive(Debug)]
@@ -16,11 +20,12 @@ impl Arm {
     }
 }
 
-impl RigDriver for Arm {
-    fn update(&mut self, params: RigUpdateParams) -> Transform {
+impl<H: Handedness + 'static> RigDriver<H> for Arm {
+    fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             rotation: params.parent.rotation,
             position: params.parent.position + params.parent.rotation * self.offset,
+            ty: PhantomData,
         }
     }
 }

--- a/src/drivers/lock_position.rs
+++ b/src/drivers/lock_position.rs
@@ -52,7 +52,7 @@ impl Default for LockPosition {
     }
 }
 
-impl<H: Handedness + 'static> RigDriver<H> for LockPosition {
+impl<H: Handedness> RigDriver<H> for LockPosition {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         let mut delta_pos = params.parent.position;
         delta_pos.x = self.x.unwrap_or(delta_pos.x);

--- a/src/drivers/lock_position.rs
+++ b/src/drivers/lock_position.rs
@@ -1,4 +1,8 @@
-use crate::{driver::RigDriver, rig::RigUpdateParams, transform::Transform};
+use std::marker::PhantomData;
+
+use crate::{
+    driver::RigDriver, handedness::Handedness, rig::RigUpdateParams, transform::Transform,
+};
 
 /// Locks/constrains the position of the camera to one or more axes
 #[derive(Debug)]
@@ -48,8 +52,8 @@ impl Default for LockPosition {
     }
 }
 
-impl RigDriver for LockPosition {
-    fn update(&mut self, params: RigUpdateParams) -> Transform {
+impl<H: Handedness + 'static> RigDriver<H> for LockPosition {
+    fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         let mut delta_pos = params.parent.position;
         delta_pos.x = self.x.unwrap_or(delta_pos.x);
         delta_pos.y = self.y.unwrap_or(delta_pos.y);
@@ -57,6 +61,7 @@ impl RigDriver for LockPosition {
         Transform {
             position: delta_pos,
             rotation: params.parent.rotation,
+            ty: PhantomData,
         }
     }
 }

--- a/src/drivers/lock_position.rs
+++ b/src/drivers/lock_position.rs
@@ -61,7 +61,7 @@ impl<H: Handedness> RigDriver<H> for LockPosition {
         Transform {
             position: delta_pos,
             rotation: params.parent.rotation,
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -55,7 +55,7 @@ impl LookAt {
     }
 }
 
-impl<H: Handedness + 'static> RigDriver<H> for LookAt {
+impl<H: Handedness> RigDriver<H> for LookAt {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         let target = self.smoothed_target.exp_smooth_towards(
             &self.target,

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -66,9 +66,17 @@ impl RigDriver for LookAt {
         let rotation = (target - params.parent.position)
             .try_normalize()
             .and_then(|forward| {
-                let right = forward.cross(Vec3::Y).try_normalize()?;
-                let up = right.cross(forward);
-                Some(Quat::from_mat3(&Mat3::from_cols(right, up, -forward)))
+                // Can achieve the same by flipping signs, but I think this makes it clearer.
+                let (right, up) = if params.right_handed {
+                    let right = forward.cross(Vec3::Y).try_normalize()?;
+                    let up = right.cross(forward);
+                    (right, up)
+                } else {
+                    let right = Vec3::Y.cross(forward).try_normalize()?;
+                    let up = forward.cross(right);
+                    (right, up)
+                };
+                Some(Quat::from_mat3(&Mat3::from_cols(right, up, forward)))
             })
             .unwrap_or_default();
 

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -79,7 +79,7 @@ impl<H: Handedness + 'static> RigDriver<H> for LookAt {
                     let up = forward.cross(right);
                     (right, up)
                 };
-                Some(Quat::from_mat3(&Mat3::from_cols(right, up, forward)))
+                Some(Quat::from_mat3(&Mat3::from_cols(right, up, -forward)))
             })
             .unwrap_or_default();
 

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -82,7 +82,7 @@ impl<H: Handedness> RigDriver<H> for LookAt {
         Transform {
             position: params.parent.position,
             rotation,
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -69,16 +69,8 @@ impl<H: Handedness> RigDriver<H> for LookAt {
         let rotation = (target - params.parent.position)
             .try_normalize()
             .and_then(|forward| {
-                // Can achieve the same by flipping signs, but I think this makes it clearer.
-                let (right, up) = if H::right_handed() {
-                    let right = forward.cross(Vec3::Y).try_normalize()?;
-                    let up = right.cross(forward);
-                    (right, up)
-                } else {
-                    let right = Vec3::Y.cross(forward).try_normalize()?;
-                    let up = forward.cross(right);
-                    (right, up)
-                };
+                let right = H::right_from_up_and_forward(Vec3::Y, forward).try_normalize()?;
+                let up = H::up_from_right_and_forward(right, forward);
                 Some(Quat::from_mat3(&Mat3::from_cols(
                     right,
                     up,

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -79,7 +79,11 @@ impl<H: Handedness> RigDriver<H> for LookAt {
                     let up = forward.cross(right);
                     (right, up)
                 };
-                Some(Quat::from_mat3(&Mat3::from_cols(right, up, -forward)))
+                Some(Quat::from_mat3(&Mat3::from_cols(
+                    right,
+                    up,
+                    forward * H::FORWARD_Z_SIGN,
+                )))
             })
             .unwrap_or_default();
 

--- a/src/drivers/position.rs
+++ b/src/drivers/position.rs
@@ -1,6 +1,10 @@
+use std::marker::PhantomData;
+
 use glam::Vec3;
 
-use crate::{driver::RigDriver, rig::RigUpdateParams, transform::Transform};
+use crate::{
+    driver::RigDriver, handedness::Handedness, rig::RigUpdateParams, transform::Transform,
+};
 
 /// Directly sets the position of the camera
 #[derive(Default, Debug)]
@@ -20,11 +24,12 @@ impl Position {
     }
 }
 
-impl RigDriver for Position {
-    fn update(&mut self, params: RigUpdateParams) -> Transform {
+impl<H: Handedness + 'static> RigDriver<H> for Position {
+    fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             position: self.position,
             rotation: params.parent.rotation,
+            ty: PhantomData,
         }
     }
 }

--- a/src/drivers/position.rs
+++ b/src/drivers/position.rs
@@ -29,7 +29,7 @@ impl<H: Handedness> RigDriver<H> for Position {
         Transform {
             position: self.position,
             rotation: params.parent.rotation,
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/drivers/position.rs
+++ b/src/drivers/position.rs
@@ -24,7 +24,7 @@ impl Position {
     }
 }
 
-impl<H: Handedness + 'static> RigDriver<H> for Position {
+impl<H: Handedness> RigDriver<H> for Position {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             position: self.position,

--- a/src/drivers/rotation.rs
+++ b/src/drivers/rotation.rs
@@ -18,7 +18,7 @@ impl Rotation {
     }
 }
 
-impl<H: Handedness + 'static> RigDriver<H> for Rotation {
+impl<H: Handedness> RigDriver<H> for Rotation {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             position: params.parent.position,

--- a/src/drivers/rotation.rs
+++ b/src/drivers/rotation.rs
@@ -1,6 +1,10 @@
+use std::marker::PhantomData;
+
 use glam::Quat;
 
-use crate::{driver::RigDriver, rig::RigUpdateParams, transform::Transform};
+use crate::{
+    driver::RigDriver, handedness::Handedness, rig::RigUpdateParams, transform::Transform,
+};
 
 /// Directly sets the rotation of the camera
 #[derive(Default, Debug)]
@@ -14,11 +18,12 @@ impl Rotation {
     }
 }
 
-impl RigDriver for Rotation {
-    fn update(&mut self, params: RigUpdateParams) -> Transform {
+impl<H: Handedness + 'static> RigDriver<H> for Rotation {
+    fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             position: params.parent.position,
             rotation: self.rotation,
+            ty: PhantomData,
         }
     }
 }

--- a/src/drivers/rotation.rs
+++ b/src/drivers/rotation.rs
@@ -23,7 +23,7 @@ impl<H: Handedness> RigDriver<H> for Rotation {
         Transform {
             position: params.parent.position,
             rotation: self.rotation,
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/drivers/smooth.rs
+++ b/src/drivers/smooth.rs
@@ -1,7 +1,10 @@
+use std::marker::PhantomData;
+
 use glam::{Quat, Vec3};
 
 use crate::{
     driver::RigDriver,
+    prelude::Handedness,
     rig::RigUpdateParams,
     transform::Transform,
     util::{ExpSmoothed, ExpSmoothingParams},
@@ -76,8 +79,8 @@ impl Smooth {
     }
 }
 
-impl RigDriver for Smooth {
-    fn update(&mut self, params: RigUpdateParams) -> Transform {
+impl<H: Handedness + 'static> RigDriver<H> for Smooth {
+    fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         let position = self.smoothed_position.exp_smooth_towards(
             &params.parent.position,
             ExpSmoothingParams {
@@ -96,6 +99,10 @@ impl RigDriver for Smooth {
             },
         );
 
-        Transform { position, rotation }
+        Transform {
+            position,
+            rotation,
+            ty: PhantomData,
+        }
     }
 }

--- a/src/drivers/smooth.rs
+++ b/src/drivers/smooth.rs
@@ -79,7 +79,7 @@ impl Smooth {
     }
 }
 
-impl<H: Handedness + 'static> RigDriver<H> for Smooth {
+impl<H: Handedness> RigDriver<H> for Smooth {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         let position = self.smoothed_position.exp_smooth_towards(
             &params.parent.position,

--- a/src/drivers/smooth.rs
+++ b/src/drivers/smooth.rs
@@ -102,7 +102,7 @@ impl<H: Handedness> RigDriver<H> for Smooth {
         Transform {
             position,
             rotation,
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/drivers/smooth.rs
+++ b/src/drivers/smooth.rs
@@ -4,7 +4,7 @@ use glam::{Quat, Vec3};
 
 use crate::{
     driver::RigDriver,
-    prelude::Handedness,
+    handedness::Handedness,
     rig::RigUpdateParams,
     transform::Transform,
     util::{ExpSmoothed, ExpSmoothingParams},

--- a/src/drivers/yaw_pitch.rs
+++ b/src/drivers/yaw_pitch.rs
@@ -2,7 +2,9 @@ use std::marker::PhantomData;
 
 use glam::{EulerRot, Quat};
 
-use crate::{driver::RigDriver, prelude::Handedness, rig::RigUpdateParams, transform::Transform};
+use crate::{
+    driver::RigDriver, handedness::Handedness, rig::RigUpdateParams, transform::Transform,
+};
 
 /// Calculate camera rotation based on yaw and pitch angles.
 ///

--- a/src/drivers/yaw_pitch.rs
+++ b/src/drivers/yaw_pitch.rs
@@ -1,6 +1,8 @@
+use std::marker::PhantomData;
+
 use glam::{EulerRot, Quat};
 
-use crate::{driver::RigDriver, rig::RigUpdateParams, transform::Transform};
+use crate::{driver::RigDriver, prelude::Handedness, rig::RigUpdateParams, transform::Transform};
 
 /// Calculate camera rotation based on yaw and pitch angles.
 ///
@@ -72,8 +74,8 @@ impl YawPitch {
     }
 }
 
-impl RigDriver for YawPitch {
-    fn update(&mut self, params: RigUpdateParams) -> Transform {
+impl<H: Handedness + 'static> RigDriver<H> for YawPitch {
+    fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             position: params.parent.position,
             rotation: Quat::from_euler(
@@ -82,6 +84,7 @@ impl RigDriver for YawPitch {
                 self.pitch_degrees.to_radians(),
                 0.0,
             ),
+            ty: PhantomData,
         }
     }
 }

--- a/src/drivers/yaw_pitch.rs
+++ b/src/drivers/yaw_pitch.rs
@@ -86,7 +86,7 @@ impl<H: Handedness> RigDriver<H> for YawPitch {
                 self.pitch_degrees.to_radians(),
                 0.0,
             ),
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }

--- a/src/drivers/yaw_pitch.rs
+++ b/src/drivers/yaw_pitch.rs
@@ -76,7 +76,7 @@ impl YawPitch {
     }
 }
 
-impl<H: Handedness + 'static> RigDriver<H> for YawPitch {
+impl<H: Handedness> RigDriver<H> for YawPitch {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
         Transform {
             position: params.parent.position,

--- a/src/drivers/yaw_pitch.rs
+++ b/src/drivers/yaw_pitch.rs
@@ -30,7 +30,7 @@ impl Default for YawPitch {
 }
 
 impl YawPitch {
-    /// Creates camera looking forward along -Z
+    /// Creates camera looking forward along Z axis (negative or positive depends on system handedness)
     pub fn new() -> Self {
         Self {
             yaw_degrees: 0.0,

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -1,7 +1,14 @@
 use std::fmt::Debug;
 
+use glam::Vec3;
+
 pub trait Handedness: Clone + Copy + Debug + 'static {
-    fn z_sign() -> f32;
+    const FORWARD_Z_SIGN: f32;
+
+    fn forward() -> Vec3 {
+        Vec3::Z * Self::FORWARD_Z_SIGN
+    }
+
     fn right_handed() -> bool;
 }
 
@@ -9,9 +16,7 @@ pub trait Handedness: Clone + Copy + Debug + 'static {
 pub struct LeftHanded {}
 
 impl Handedness for LeftHanded {
-    fn z_sign() -> f32 {
-        1.0
-    }
+    const FORWARD_Z_SIGN: f32 = 1.0;
 
     fn right_handed() -> bool {
         false
@@ -22,9 +27,7 @@ impl Handedness for LeftHanded {
 pub struct RightHanded {}
 
 impl Handedness for RightHanded {
-    fn z_sign() -> f32 {
-        -1.0
-    }
+    const FORWARD_Z_SIGN: f32 = -1.0;
 
     fn right_handed() -> bool {
         true

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -1,0 +1,32 @@
+use std::fmt::Debug;
+
+pub trait Handedness: Clone + Copy + Debug {
+    fn z_sign() -> f32;
+    fn right_handed() -> bool;
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct LeftHanded {}
+
+impl Handedness for LeftHanded {
+    fn z_sign() -> f32 {
+        1.0
+    }
+
+    fn right_handed() -> bool {
+        false
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct RightHanded {}
+
+impl Handedness for RightHanded {
+    fn z_sign() -> f32 {
+        -1.0
+    }
+
+    fn right_handed() -> bool {
+        true
+    }
+}

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -1,6 +1,6 @@
 use std::fmt::Debug;
 
-pub trait Handedness: Clone + Copy + Debug {
+pub trait Handedness: Clone + Copy + Debug + 'static {
     fn z_sign() -> f32;
     fn right_handed() -> bool;
 }

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -13,7 +13,7 @@ pub trait Handedness: Clone + Copy + Debug + 'static {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct LeftHanded {}
+pub struct LeftHanded;
 
 impl Handedness for LeftHanded {
     const FORWARD_Z_SIGN: f32 = 1.0;
@@ -24,7 +24,7 @@ impl Handedness for LeftHanded {
 }
 
 #[derive(Clone, Copy, Debug)]
-pub struct RightHanded {}
+pub struct RightHanded;
 
 impl Handedness for RightHanded {
     const FORWARD_Z_SIGN: f32 = -1.0;

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -9,7 +9,8 @@ pub trait Handedness: Clone + Copy + Debug + 'static {
         Vec3::Z * Self::FORWARD_Z_SIGN
     }
 
-    fn right_handed() -> bool;
+    fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3;
+    fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -18,8 +19,12 @@ pub struct LeftHanded;
 impl Handedness for LeftHanded {
     const FORWARD_Z_SIGN: f32 = 1.0;
 
-    fn right_handed() -> bool {
-        false
+    fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3 {
+        up.cross(forward)
+    }
+
+    fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3 {
+        forward.cross(right)
     }
 }
 
@@ -29,7 +34,11 @@ pub struct RightHanded;
 impl Handedness for RightHanded {
     const FORWARD_Z_SIGN: f32 = -1.0;
 
-    fn right_handed() -> bool {
-        true
+    fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3 {
+        forward.cross(up)
+    }
+
+    fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3 {
+        right.cross(forward)
     }
 }

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -1,13 +1,10 @@
 use std::fmt::Debug;
 
-use glam::Vec3;
+use glam::{const_vec3, Vec3};
 
 pub trait Handedness: Clone + Copy + Debug + 'static {
     const FORWARD_Z_SIGN: f32;
-
-    fn forward() -> Vec3 {
-        Vec3::Z * Self::FORWARD_Z_SIGN
-    }
+    const FORWARD: Vec3 = const_vec3!([0.0, 0.0, Self::FORWARD_Z_SIGN]);
 
     fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3;
     fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@
 //! [`YawPitch`]: drivers/yaw_pitch/struct.YawPitch.html
 //! [`CameraRig::update`]: rig/struct.CameraRig.html#method.update
 
+pub mod handedness;
 pub mod driver;
 pub mod drivers;
 pub mod prelude;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,9 +31,9 @@
 //! [`YawPitch`]: drivers/yaw_pitch/struct.YawPitch.html
 //! [`CameraRig::update`]: rig/struct.CameraRig.html#method.update
 
-pub mod handedness;
 pub mod driver;
 pub mod drivers;
+pub mod handedness;
 pub mod prelude;
 pub mod rig;
 pub mod transform;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! rotation via yaw and pitch angles. Each frame, driver parameters can be modified,
 //! and will affect the subsequent call to [`CameraRig::update`], which provides the final camera transformation.
 //!
-//! Please note that `dolly` currently assumes the right-handed OpenGL-style coordinate system.
 //!
 //! # Example
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 //! rotation via yaw and pitch angles. Each frame, driver parameters can be modified,
 //! and will affect the subsequent call to [`CameraRig::update`], which provides the final camera transformation.
 //!
-//!
 //! # Example
 //!
 //! ```

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,4 +1,1 @@
 pub use crate::{drivers::*, handedness::*, rig::CameraRig};
-
-// /// Default to right-handed as the original crate.
-// pub type CameraRig = crate::rig::CameraRig::<RightHanded>;

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,1 +1,4 @@
-pub use crate::{drivers::*, rig::CameraRig};
+pub use crate::{drivers::*, handedness::*, rig::CameraRig};
+
+// /// Default to right-handed as the original crate.
+// pub type CameraRig = crate::rig::CameraRig::<RightHanded>;

--- a/src/rig.rs
+++ b/src/rig.rs
@@ -8,7 +8,7 @@ use std::marker::PhantomData;
 
 /// A chain of drivers, calculating displacements, and animating in succession.
 #[derive(Debug)]
-pub struct CameraRig<H: Handedness + 'static = RightHanded> {
+pub struct CameraRig<H: Handedness = RightHanded> {
     ///
     pub drivers: Vec<Box<dyn RigDriverTraits<H>>>,
 
@@ -22,7 +22,7 @@ pub struct CameraRig<H: Handedness + 'static = RightHanded> {
 struct RigUpdateToken;
 
 ///
-pub struct RigUpdateParams<'a, H: Handedness + 'static> {
+pub struct RigUpdateParams<'a, H: Handedness> {
     ///
     pub parent: &'a Transform<H>,
     ///
@@ -33,9 +33,9 @@ pub struct RigUpdateParams<'a, H: Handedness + 'static> {
     _token: RigUpdateToken,
 }
 
-impl<H: Handedness + 'static> CameraRig<H> {
+impl<H: Handedness> CameraRig<H> {
     /// Returns the first driver of the matching type. Panics if no such driver is present.
-    pub fn driver_mut<T: RigDriver<H> + 'static>(&mut self) -> &mut T {
+    pub fn driver_mut<T: RigDriver<H>>(&mut self) -> &mut T {
         self.try_driver_mut::<T>().unwrap_or_else(|| {
             panic!(
                 "No {} driver found in the CameraRig",
@@ -45,7 +45,7 @@ impl<H: Handedness + 'static> CameraRig<H> {
     }
 
     /// Returns the Some with the first driver of the matching type, or `None` if no such driver is present.
-    pub fn try_driver_mut<T: RigDriver<H> + 'static>(&mut self) -> Option<&mut T> {
+    pub fn try_driver_mut<T: RigDriver<H>>(&mut self) -> Option<&mut T> {
         self.drivers
             .iter_mut()
             .find_map(|driver| driver.as_mut().as_any_mut().downcast_mut::<T>())
@@ -82,12 +82,12 @@ impl<H: Handedness + 'static> CameraRig<H> {
 }
 
 ///
-pub struct CameraRigBuilder<H: Handedness + 'static> {
+pub struct CameraRigBuilder<H: Handedness> {
     drivers: Vec<Box<dyn RigDriverTraits<H>>>,
     ty: PhantomData<H>,
 }
 
-impl<H: Handedness + 'static> CameraRigBuilder<H> {
+impl<H: Handedness> CameraRigBuilder<H> {
     ///
     pub fn with(mut self, driver: impl RigDriverTraits<H>) -> Self {
         self.drivers.push(Box::new(driver));

--- a/src/rig.rs
+++ b/src/rig.rs
@@ -15,7 +15,7 @@ pub struct CameraRig<H: Handedness = RightHanded> {
     ///
     pub final_transform: Transform<H>,
 
-    ty: PhantomData<H>,
+    phantom: PhantomData<H>,
 }
 
 // Prevents user calls to `RigDriver::update`. All updates must come from `CameraRig::update`.
@@ -28,7 +28,7 @@ pub struct RigUpdateParams<'a, H: Handedness> {
     ///
     pub delta_time_seconds: f32,
 
-    ty: PhantomData<H>,
+    phantom: PhantomData<H>,
 
     _token: RigUpdateToken,
 }
@@ -61,7 +61,7 @@ impl<H: Handedness> CameraRig<H> {
             let transform = driver.update(RigUpdateParams {
                 parent: &parent_transform,
                 delta_time_seconds,
-                ty: PhantomData,
+                phantom: PhantomData,
                 _token: RigUpdateToken,
             });
 
@@ -76,7 +76,7 @@ impl<H: Handedness> CameraRig<H> {
     pub fn builder() -> CameraRigBuilder<H> {
         CameraRigBuilder {
             drivers: Default::default(),
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 }
@@ -84,7 +84,7 @@ impl<H: Handedness> CameraRig<H> {
 ///
 pub struct CameraRigBuilder<H: Handedness> {
     drivers: Vec<Box<dyn RigDriverTraits<H>>>,
-    ty: PhantomData<H>,
+    phantom: PhantomData<H>,
 }
 
 impl<H: Handedness> CameraRigBuilder<H> {
@@ -100,7 +100,7 @@ impl<H: Handedness> CameraRigBuilder<H> {
             drivers: self.drivers,
             // Initialize with a dummy identity transform. Will be overridden in a moment.
             final_transform: Transform::IDENTITY,
-            ty: PhantomData,
+            phantom: PhantomData,
         };
 
         // Update once to find the final transform

--- a/src/rig.rs
+++ b/src/rig.rs
@@ -1,40 +1,42 @@
 use crate::{
     driver::{RigDriver, RigDriverTraits},
+    handedness::Handedness,
+    prelude::RightHanded,
     transform::Transform,
 };
 use core::fmt::Debug;
+use std::marker::PhantomData;
 
 /// A chain of drivers, calculating displacements, and animating in succession.
 #[derive(Debug)]
-pub struct CameraRig {
+pub struct CameraRig<H: Handedness + 'static = RightHanded> {
     ///
-    pub drivers: Vec<Box<dyn RigDriverTraits>>,
+    pub drivers: Vec<Box<dyn RigDriverTraits<H>>>,
 
     ///
-    pub final_transform: Transform,
+    pub final_transform: Transform<H>,
 
-    ///
-    right_handed: bool,
+    ty: PhantomData<H>,
 }
 
 // Prevents user calls to `RigDriver::update`. All updates must come from `CameraRig::update`.
 struct RigUpdateToken;
 
 ///
-pub struct RigUpdateParams<'a> {
+pub struct RigUpdateParams<'a, H: Handedness + 'static> {
     ///
-    pub parent: &'a Transform,
+    pub parent: &'a Transform<H>,
     ///
     pub delta_time_seconds: f32,
-    ///
-    pub right_handed: bool,
+
+    ty: PhantomData<H>,
 
     _token: RigUpdateToken,
 }
 
-impl CameraRig {
+impl<H: Handedness + 'static> CameraRig<H> {
     /// Returns the first driver of the matching type. Panics if no such driver is present.
-    pub fn driver_mut<T: RigDriver + 'static>(&mut self) -> &mut T {
+    pub fn driver_mut<T: RigDriver<H> + 'static>(&mut self) -> &mut T {
         self.try_driver_mut::<T>().unwrap_or_else(|| {
             panic!(
                 "No {} driver found in the CameraRig",
@@ -44,7 +46,7 @@ impl CameraRig {
     }
 
     /// Returns the Some with the first driver of the matching type, or `None` if no such driver is present.
-    pub fn try_driver_mut<T: RigDriver + 'static>(&mut self) -> Option<&mut T> {
+    pub fn try_driver_mut<T: RigDriver<H> + 'static>(&mut self) -> Option<&mut T> {
         self.drivers
             .iter_mut()
             .find_map(|driver| driver.as_mut().as_any_mut().downcast_mut::<T>())
@@ -53,14 +55,14 @@ impl CameraRig {
     /// Runs all the drivers in sequence, animating the rig, and producing a final transform of the camera.
     ///
     /// Camera rigs are approximately framerate independent, so `update` can be called at any frequency.
-    pub fn update(&mut self, delta_time_seconds: f32) -> Transform {
+    pub fn update(&mut self, delta_time_seconds: f32) -> Transform<H> {
         let mut parent_transform = Transform::IDENTITY;
 
         for driver in self.drivers.iter_mut() {
             let transform = driver.update(RigUpdateParams {
                 parent: &parent_transform,
                 delta_time_seconds,
-                right_handed: self.right_handed,
+                ty: PhantomData,
                 _token: RigUpdateToken,
             });
 
@@ -71,51 +73,64 @@ impl CameraRig {
         self.final_transform
     }
 
-    /// Return handedness of the camera rig
-    pub fn is_right_handed(&self) -> bool {
-        self.right_handed
-    }
-
     /// Use this to make a new rig
-    pub fn builder() -> CameraRigBuilder {
+    pub fn builder() -> CameraRigBuilder<H> {
         CameraRigBuilder {
             drivers: Default::default(),
+            ty: PhantomData,
         }
     }
 }
 
 ///
-pub struct CameraRigBuilder {
-    drivers: Vec<Box<dyn RigDriverTraits>>,
+pub struct CameraRigBuilder<H: Handedness + 'static> {
+    drivers: Vec<Box<dyn RigDriverTraits<H>>>,
+    ty: PhantomData<H>,
 }
 
-impl CameraRigBuilder {
+impl<H: Handedness + 'static> CameraRigBuilder<H> {
     ///
-    pub fn with(mut self, driver: impl RigDriverTraits) -> Self {
+    pub fn with(mut self, driver: impl RigDriverTraits<H>) -> Self {
         self.drivers.push(Box::new(driver));
         self
     }
 
     ///
-    fn build_internal(self, right_handed: bool) -> CameraRig {
+    pub fn build(self) -> CameraRig<H> {
         let mut rig = CameraRig {
             drivers: self.drivers,
             // Initialize with a dummy identity transform. Will be overridden in a moment.
             final_transform: Transform::IDENTITY,
-            right_handed,
+            ty: PhantomData,
         };
 
         // Update once to find the final transform
         rig.update(0.0);
         rig
     }
-
-    ///
-    pub fn build(self) -> CameraRig {
-        self.build_internal(true)
-    }
-
-    pub fn build_lh(self) -> CameraRig {
-        self.build_internal(false)
-    }
 }
+
+//
+
+// pub trait BuilderWithHandedness<H: Handedness + 'static> {
+//     fn build(self) -> CameraRig<H>;
+// }
+
+// impl BuilderWithHandedness<RightHanded> for CameraRigBuilder<RightHanded> {
+//     fn build(self) -> CameraRig<RightHanded> {
+//         self.build_internal()
+//     }
+// }
+
+// impl BuilderWithHandedness<LeftHanded> for CameraRigBuilder<LeftHanded> {
+//     fn build(self) -> CameraRig<LeftHanded> {
+//         self.build_internal()
+//     }
+// }
+
+// EHRM.............
+// fn test() {
+//     type CameraRig2 = CameraRig<LeftHanded>;
+
+//     let cam = CameraRig2::builder().build();
+// }

--- a/src/rig.rs
+++ b/src/rig.rs
@@ -1,7 +1,6 @@
 use crate::{
     driver::{RigDriver, RigDriverTraits},
-    handedness::Handedness,
-    prelude::RightHanded,
+    handedness::{Handedness, RightHanded},
     transform::Transform,
 };
 use core::fmt::Debug;

--- a/src/rig.rs
+++ b/src/rig.rs
@@ -108,28 +108,3 @@ impl<H: Handedness + 'static> CameraRigBuilder<H> {
         rig
     }
 }
-
-//
-
-// pub trait BuilderWithHandedness<H: Handedness + 'static> {
-//     fn build(self) -> CameraRig<H>;
-// }
-
-// impl BuilderWithHandedness<RightHanded> for CameraRigBuilder<RightHanded> {
-//     fn build(self) -> CameraRig<RightHanded> {
-//         self.build_internal()
-//     }
-// }
-
-// impl BuilderWithHandedness<LeftHanded> for CameraRigBuilder<LeftHanded> {
-//     fn build(self) -> CameraRig<LeftHanded> {
-//         self.build_internal()
-//     }
-// }
-
-// EHRM.............
-// fn test() {
-//     type CameraRig2 = CameraRig<LeftHanded>;
-
-//     let cam = CameraRig2::builder().build();
-// }

--- a/src/rig.rs
+++ b/src/rig.rs
@@ -12,6 +12,9 @@ pub struct CameraRig {
 
     ///
     pub final_transform: Transform,
+
+    ///
+    right_handed: bool,
 }
 
 // Prevents user calls to `RigDriver::update`. All updates must come from `CameraRig::update`.
@@ -23,6 +26,9 @@ pub struct RigUpdateParams<'a> {
     pub parent: &'a Transform,
     ///
     pub delta_time_seconds: f32,
+    ///
+    pub right_handed: bool,
+
     _token: RigUpdateToken,
 }
 
@@ -54,6 +60,7 @@ impl CameraRig {
             let transform = driver.update(RigUpdateParams {
                 parent: &parent_transform,
                 delta_time_seconds,
+                right_handed: self.right_handed,
                 _token: RigUpdateToken,
             });
 
@@ -62,6 +69,11 @@ impl CameraRig {
 
         self.final_transform = parent_transform;
         self.final_transform
+    }
+
+    /// Return handedness of the camera rig
+    pub fn is_right_handed(&self) -> bool {
+        self.right_handed
     }
 
     /// Use this to make a new rig
@@ -85,15 +97,25 @@ impl CameraRigBuilder {
     }
 
     ///
-    pub fn build(self) -> CameraRig {
+    fn build_internal(self, right_handed: bool) -> CameraRig {
         let mut rig = CameraRig {
             drivers: self.drivers,
             // Initialize with a dummy identity transform. Will be overridden in a moment.
             final_transform: Transform::IDENTITY,
+            right_handed,
         };
 
         // Update once to find the final transform
         rig.update(0.0);
         rig
+    }
+
+    ///
+    pub fn build(self) -> CameraRig {
+        self.build_internal(true)
+    }
+
+    pub fn build_lh(self) -> CameraRig {
+        self.build_internal(false)
     }
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -37,9 +37,9 @@ impl<H: Handedness> Transform<H> {
         self.rotation * Vec3::Y
     }
 
-    /// -Z
+    /// +/-Z
     pub fn forward(&self) -> Vec3 {
-        self.rotation * Vec3::Z * H::z_sign()
+        self.rotation * H::forward()
     }
 
     ///

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -30,8 +30,9 @@ impl Transform {
     }
 
     /// -Z
-    pub fn forward(&self) -> Vec3 {
-        self.rotation * -Vec3::Z
+    pub fn forward(&self, right_handed: bool) -> Vec3 {
+        let sign = if right_handed { -1.0 } else { 1.0 };
+        self.rotation * Vec3::Z * sign
     }
 
     ///

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -9,7 +9,7 @@ use crate::handedness::Handedness;
 pub struct Transform<H: Handedness> {
     pub position: Vec3,
     pub rotation: Quat,
-    pub ty: PhantomData<H>,
+    pub phantom: PhantomData<H>,
 }
 
 impl<H: Handedness> Transform<H> {
@@ -18,7 +18,7 @@ impl<H: Handedness> Transform<H> {
         Self {
             position,
             rotation,
-            ty: PhantomData,
+            phantom: PhantomData,
         }
     }
 
@@ -46,6 +46,6 @@ impl<H: Handedness> Transform<H> {
     pub const IDENTITY: Transform<H> = Transform {
         position: Vec3::ZERO,
         rotation: Quat::IDENTITY,
-        ty: PhantomData,
+        phantom: PhantomData,
     };
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -6,13 +6,13 @@ use crate::handedness::Handedness;
 
 /// A thin wrapper over a `Vec3` and a `Quat`
 #[derive(Clone, Copy, Debug)]
-pub struct Transform<H: Handedness + 'static> {
+pub struct Transform<H: Handedness> {
     pub position: Vec3,
     pub rotation: Quat,
     pub ty: PhantomData<H>,
 }
 
-impl<H: Handedness + 'static> Transform<H> {
+impl<H: Handedness> Transform<H> {
     ///
     pub fn from_position_rotation(position: Vec3, rotation: Quat) -> Self {
         Self {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -1,17 +1,25 @@
 use core::fmt::Debug;
 use glam::{Quat, Vec3};
+use std::marker::PhantomData;
+
+use crate::handedness::Handedness;
 
 /// A thin wrapper over a `Vec3` and a `Quat`
 #[derive(Clone, Copy, Debug)]
-pub struct Transform {
+pub struct Transform<H: Handedness + 'static> {
     pub position: Vec3,
     pub rotation: Quat,
+    pub ty: PhantomData<H>,
 }
 
-impl Transform {
+impl<H: Handedness + 'static> Transform<H> {
     ///
     pub fn from_position_rotation(position: Vec3, rotation: Quat) -> Self {
-        Self { position, rotation }
+        Self {
+            position,
+            rotation,
+            ty: PhantomData,
+        }
     }
 
     ///
@@ -30,14 +38,14 @@ impl Transform {
     }
 
     /// -Z
-    pub fn forward(&self, right_handed: bool) -> Vec3 {
-        let sign = if right_handed { -1.0 } else { 1.0 };
-        self.rotation * Vec3::Z * sign
+    pub fn forward(&self) -> Vec3 {
+        self.rotation * Vec3::Z * H::z_sign()
     }
 
     ///
-    pub const IDENTITY: Transform = Transform {
+    pub const IDENTITY: Transform<H> = Transform {
         position: Vec3::ZERO,
         rotation: Quat::IDENTITY,
+        ty: PhantomData,
     };
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -39,7 +39,7 @@ impl<H: Handedness> Transform<H> {
 
     /// +/-Z
     pub fn forward(&self) -> Vec3 {
-        self.rotation * H::forward()
+        self.rotation * H::FORWARD
     }
 
     ///


### PR DESCRIPTION
New: 
Implement left-handed system support using generics + handedness trait. CameraRig defaults to RightHanded.

Old: 
The comment below doesn't apply anymore, as the entire PR has pretty much changed :)

> I tried to keep the public API unchanged, but alas the Transform `forward()` function didn't make the cut 😛 as I didn't want to pass a nasty bool inside Transform as well.
>
> Users should be able to simply call `build_lh()`. Works on my machine™.