### PR TITLE
Made CameraRig phantom field pub so it can support bevy_dolly

### DIFF
--- a/src/rig.rs
+++ b/src/rig.rs
@@ -15,7 +15,7 @@ pub struct CameraRig<H: Handedness = RightHanded> {
     ///
     pub final_transform: Transform<H>,
 
-    phantom: PhantomData<H>,
+    pub phantom: PhantomData<H>,
 }
 
 // Prevents user calls to `RigDriver::update`. All updates must come from `CameraRig::update`.


### PR DESCRIPTION
From `bevy 0.6` and forward, all components require the `#[derive(Component)]` which means that `bevy_dolly`'s current impl. of dolly cannot compile. In order to use CameraRig as a component in `bevy_ecs`, the newtype pattern is required as shown:
```rs
#[derive(Component, Deref, DerefMut)]
pub struct BevyCameraRig(CameraRig<RightHanded>);
```
However, this also means that the builder function has to return BevyCameraRig. And seeing as we have to reimplement the CameraRigBuilder to return BevyCameraRig (I see no other option). We have to create `CameraRig`, though this is currently not feasible outside the crate itself due to the phantom field in CameraRig being non-pub.

So...
 <img src="https://user-images.githubusercontent.com/25123512/168451290-1cd1c636-a7c4-4df2-9cd2-1428517af008.png" alt="An image showing the Bernie Sanders meme: I Am Once Again Asking For Your Financial Support. Bernie Sanders' head has been replaced with BlackPhlox's profile picture and the financial part of the text has been replaced with bevy, now saying: I Am Once Again Asking For Your Bevy Support." width="500"/>