### PR TITLE
cargo: Bump glam upper version bound to 0.21

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["game-development"]
 readme = "crates-io.md"
 
 [dependencies]
-glam = ">=0.15, <=0.20"
+glam = ">=0.15, <=0.21"
 
 [dev-dependencies]
 macroquad = "0.3"

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -1,10 +1,14 @@
 use std::fmt::Debug;
 
-use glam::{const_vec3, Vec3};
+use glam::Vec3;
 
 pub trait Handedness: Clone + Copy + Debug + 'static {
     const FORWARD_Z_SIGN: f32;
-    const FORWARD: Vec3 = const_vec3!([0.0, 0.0, Self::FORWARD_Z_SIGN]);
+    // `glam::const_vec3!` is deprecated  since 0.21 and to be replaced with
+    // `glam::Vec3::new(0.0, 0.0, Self::FORWARD_Z_SIGN)`. Consider replacing
+    // it when bumping glam's minimum version to 0.21.
+    #[allow(deprecated)]
+    const FORWARD: Vec3 = glam::const_vec3!([0.0, 0.0, Self::FORWARD_Z_SIGN]);
 
     fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3;
     fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3;


### PR DESCRIPTION
Note that `const_vec3!` is now deprecated in favor of new `const fn`s, should we switch to that and drop the minimum bound? This may also have implications on MSRV though. See also https://github.com/MarijnS95/dolly/compare/glam-0.21-const.
