### PR TITLE
Upgrade `glam` to `0.22`, bump minimum to `0.21`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,10 @@ documentation = "https://docs.rs/dolly"
 keywords = ["gamedev", "camera", "3d"]
 categories = ["game-development"]
 readme = "crates-io.md"
+rust-version = "1.58.1"
 
 [dependencies]
-glam = ">=0.15, <=0.21"
+glam = ">=0.21, <=0.22"
 
 [dev-dependencies]
 macroquad = "0.3"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Crates.io](https://img.shields.io/crates/v/dolly.svg)](https://crates.io/crates/dolly)
 [![Docs](https://docs.rs/dolly/badge.svg)](https://docs.rs/dolly)
+[![Rust 1.58.1](https://img.shields.io/badge/Rust-1.58.1-fc8d62?logo=rust)](https://github.com/rust-lang/rust/blob/master/RELEASES.md#version-1581-2022-01-19)
 
 Combine simple building blocks to create smooth cameras: first-person, chase, orbit, look-at, you name it!
 

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -4,11 +4,7 @@ use glam::Vec3;
 
 pub trait Handedness: Clone + Copy + Debug + 'static {
     const FORWARD_Z_SIGN: f32;
-    // `glam::const_vec3!` is deprecated  since 0.21 and to be replaced with
-    // `glam::Vec3::new(0.0, 0.0, Self::FORWARD_Z_SIGN)`. Consider replacing
-    // it when bumping glam's minimum version to 0.21.
-    #[allow(deprecated)]
-    const FORWARD: Vec3 = glam::const_vec3!([0.0, 0.0, Self::FORWARD_Z_SIGN]);
+    const FORWARD: Vec3 = glam::vec3(0.0, 0.0, Self::FORWARD_Z_SIGN);
 
     fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3;
     fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3;


### PR DESCRIPTION
`glam` finally removed the deprecated `const_vec3!` macro constructor in favour of proper `const fn`s, supported for both arrays and loose per-component arguments.  This however bumps the minimum requirement to `0.21` where these `const fn`s were first introduced, and propagates its 1.58.1 MSRV.
