### PR TITLE
Use mint types in public API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ readme = "crates-io.md"
 rust-version = "1.60"
 
 [dependencies]
-glam = ">=0.21, <=0.24"
+glam = { version = ">=0.21, <=0.24", features = ["mint"] }
+mint = "0.5.9"
 
 [dev-dependencies]
 macroquad = "0.3"

--- a/examples/nested_driver.rs
+++ b/examples/nested_driver.rs
@@ -154,6 +154,14 @@ impl DollyToMacroquad for mint::Vector3<f32> {
     }
 }
 
+impl DollyToMacroquad for mint::Point3<f32> {
+    type Target = Vec3;
+
+    fn d2m(self) -> Self::Target {
+        <[f32; 3]>::from(self).into()
+    }
+}
+
 fn get_move_input() -> glam::Vec3 {
     const SPEED: f32 = 0.05;
 

--- a/examples/orbit.rs
+++ b/examples/orbit.rs
@@ -1,7 +1,16 @@
 // Based on https://github.com/not-fl3/macroquad/blob/97a99d00155cb7531f4432a2eb5f3c587e22f9b3/examples/3d.rs
 
 use dolly::prelude::*;
-use macroquad::prelude::*;
+use macroquad::{
+    prelude::{
+        draw_cube, draw_cube_wires, draw_grid, draw_sphere, is_key_pressed, set_camera,
+        set_default_camera, vec3, Camera3D, KeyCode, BLACK, BLUE, DARKBLUE, DARKGREEN, GRAY,
+        LIGHTGRAY, WHITE, YELLOW,
+    },
+    text::draw_text,
+    time::get_frame_time,
+    window::{clear_background, next_frame},
+};
 
 #[macroquad::main("dolly orbit example")]
 async fn main() {
@@ -9,7 +18,7 @@ async fn main() {
     let mut camera: CameraRig = CameraRig::builder()
         .with(YawPitch::new().yaw_degrees(45.0).pitch_degrees(-30.0))
         .with(Smooth::new_rotation(1.5))
-        .with(Arm::new(dolly::glam::Vec3::Z * 8.0))
+        .with(Arm::new(glam::Vec3::Z * 8.0))
         .build();
 
     loop {
@@ -30,8 +39,11 @@ async fn main() {
         // the two different `glam` versions to talk to each other.
         set_camera(&Camera3D {
             position: <[f32; 3]>::from(camera_xform.position).into(),
-            up: <[f32; 3]>::from(camera_xform.up()).into(),
-            target: <[f32; 3]>::from(camera_xform.position + camera_xform.forward()).into(),
+            up: <[f32; 3]>::from(camera_xform.up::<glam::Vec3>()).into(),
+            target: <[f32; 3]>::from(
+                glam::Vec3::from(camera_xform.position) + camera_xform.forward::<glam::Vec3>(),
+            )
+            .into(),
             ..Default::default()
         });
 

--- a/src/drivers/arm.rs
+++ b/src/drivers/arm.rs
@@ -19,7 +19,7 @@ impl Arm {
     where
         V: Into<mint::Vector3<f32>>,
     {
-        let offset = offset.into().into();
+        let offset = offset.into();
 
         Self { offset }
     }

--- a/src/drivers/arm.rs
+++ b/src/drivers/arm.rs
@@ -1,6 +1,6 @@
 use std::marker::PhantomData;
 
-use glam::Vec3;
+use glam::{Quat, Vec3};
 
 use crate::{
     driver::RigDriver, handedness::Handedness, rig::RigUpdateParams, transform::Transform,
@@ -10,21 +10,32 @@ use crate::{
 #[derive(Debug)]
 pub struct Arm {
     ///
-    pub offset: Vec3,
+    pub offset: mint::Vector3<f32>,
 }
 
 impl Arm {
     ///
-    pub fn new(offset: Vec3) -> Self {
+    pub fn new<V>(offset: V) -> Self
+    where
+        V: Into<mint::Vector3<f32>>,
+    {
+        let offset = offset.into().into();
+
         Self { offset }
     }
 }
 
 impl<H: Handedness> RigDriver<H> for Arm {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
+        let parent_position: Vec3 = params.parent.position.into();
+        let parent_rotation: Quat = params.parent.rotation.into();
+        let offset: Vec3 = self.offset.into();
+
+        let position = parent_position + parent_rotation * offset;
+
         Transform {
             rotation: params.parent.rotation,
-            position: params.parent.position + params.parent.rotation * self.offset,
+            position: position.into(),
             phantom: PhantomData,
         }
     }

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -19,7 +19,7 @@ pub struct LookAt {
     pub smoothness: f32,
 
     /// The world-space position to look at
-    pub target: Vec3,
+    pub target: mint::Vector3<f32>,
 
     // The scale with which smoothing should be applied to the target position
     output_offset_scale: f32,
@@ -29,7 +29,12 @@ pub struct LookAt {
 
 impl LookAt {
     ///
-    pub fn new(target: Vec3) -> Self {
+    pub fn new<V>(target: V) -> Self
+    where
+        V: Into<mint::Vector3<f32>>,
+    {
+        let target = target.into().into();
+
         Self {
             smoothness: 0.0,
             output_offset_scale: 1.0,
@@ -57,8 +62,10 @@ impl LookAt {
 
 impl<H: Handedness> RigDriver<H> for LookAt {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
+        let other: Vec3 = self.target.into();
+
         let target = self.smoothed_target.exp_smooth_towards(
-            &self.target,
+            &other,
             ExpSmoothingParams {
                 smoothness: self.smoothness,
                 output_offset_scale: self.output_offset_scale,
@@ -66,7 +73,8 @@ impl<H: Handedness> RigDriver<H> for LookAt {
             },
         );
 
-        let rotation = look_at::<H>(target - params.parent.position);
+        let parent_position: Vec3 = From::from(params.parent.position);
+        let rotation = look_at::<H, _, _>(target - parent_position);
 
         Transform {
             position: params.parent.position,

--- a/src/drivers/look_at.rs
+++ b/src/drivers/look_at.rs
@@ -19,7 +19,7 @@ pub struct LookAt {
     pub smoothness: f32,
 
     /// The world-space position to look at
-    pub target: mint::Vector3<f32>,
+    pub target: mint::Point3<f32>,
 
     // The scale with which smoothing should be applied to the target position
     output_offset_scale: f32,
@@ -29,11 +29,11 @@ pub struct LookAt {
 
 impl LookAt {
     ///
-    pub fn new<V>(target: V) -> Self
+    pub fn new<P>(target: P) -> Self
     where
-        V: Into<mint::Vector3<f32>>,
+        P: Into<mint::Point3<f32>>,
     {
-        let target = target.into().into();
+        let target = target.into();
 
         Self {
             smoothness: 0.0,

--- a/src/drivers/position.rs
+++ b/src/drivers/position.rs
@@ -7,20 +7,38 @@ use crate::{
 };
 
 /// Directly sets the position of the camera
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct Position {
-    pub position: Vec3,
+    pub position: mint::Vector3<f32>,
+}
+
+impl Default for Position {
+    fn default() -> Self {
+        Self {
+            position: Vec3::default().into(),
+        }
+    }
 }
 
 impl Position {
     ///
-    pub fn new(position: Vec3) -> Self {
+    pub fn new<V>(position: V) -> Self
+    where
+        V: Into<mint::Vector3<f32>>,
+    {
+        let position = position.into();
+
         Self { position }
     }
 
     /// Add the specified vector to the position of this component
-    pub fn translate(&mut self, move_vec: Vec3) {
-        self.position += move_vec;
+    pub fn translate<V>(&mut self, move_vec: V)
+    where
+        V: Into<mint::Vector3<f32>>,
+    {
+        let position: Vec3 = From::from(self.position);
+        let move_vec: Vec3 = move_vec.into().into();
+        self.position = (position + move_vec).into();
     }
 }
 

--- a/src/drivers/position.rs
+++ b/src/drivers/position.rs
@@ -9,7 +9,7 @@ use crate::{
 /// Directly sets the position of the camera
 #[derive(Debug)]
 pub struct Position {
-    pub position: mint::Vector3<f32>,
+    pub position: mint::Point3<f32>,
 }
 
 impl Default for Position {
@@ -22,9 +22,9 @@ impl Default for Position {
 
 impl Position {
     ///
-    pub fn new<V>(position: V) -> Self
+    pub fn new<P>(position: P) -> Self
     where
-        V: Into<mint::Vector3<f32>>,
+        P: Into<mint::Point3<f32>>,
     {
         let position = position.into();
 

--- a/src/drivers/rotation.rs
+++ b/src/drivers/rotation.rs
@@ -7,13 +7,26 @@ use crate::{
 };
 
 /// Directly sets the rotation of the camera
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct Rotation {
-    pub rotation: Quat,
+    pub rotation: mint::Quaternion<f32>,
+}
+
+impl Default for Rotation {
+    fn default() -> Self {
+        Self {
+            rotation: Quat::default().into(),
+        }
+    }
 }
 
 impl Rotation {
-    pub fn new(rotation: Quat) -> Self {
+    pub fn new<Q>(rotation: Q) -> Self
+    where
+        Q: Into<mint::Quaternion<f32>>,
+    {
+        let rotation = rotation.into().into();
+
         Self { rotation }
     }
 }

--- a/src/drivers/rotation.rs
+++ b/src/drivers/rotation.rs
@@ -25,7 +25,7 @@ impl Rotation {
     where
         Q: Into<mint::Quaternion<f32>>,
     {
-        let rotation = rotation.into().into();
+        let rotation = rotation.into();
 
         Self { rotation }
     }

--- a/src/drivers/smooth.rs
+++ b/src/drivers/smooth.rs
@@ -81,8 +81,11 @@ impl Smooth {
 
 impl<H: Handedness> RigDriver<H> for Smooth {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
+        let parent_position = From::from(params.parent.position);
+        let parent_rotation = From::from(params.parent.rotation);
+
         let position = self.smoothed_position.exp_smooth_towards(
-            &params.parent.position,
+            &parent_position,
             ExpSmoothingParams {
                 smoothness: self.position_smoothness,
                 output_offset_scale: self.output_offset_scale,
@@ -91,7 +94,7 @@ impl<H: Handedness> RigDriver<H> for Smooth {
         );
 
         let rotation = self.smoothed_rotation.exp_smooth_towards(
-            &params.parent.rotation,
+            &parent_rotation,
             ExpSmoothingParams {
                 smoothness: self.rotation_smoothness,
                 output_offset_scale: self.output_offset_scale,
@@ -100,8 +103,8 @@ impl<H: Handedness> RigDriver<H> for Smooth {
         );
 
         Transform {
-            position,
-            rotation,
+            position: position.into(),
+            rotation: rotation.into(),
             phantom: PhantomData,
         }
     }

--- a/src/drivers/yaw_pitch.rs
+++ b/src/drivers/yaw_pitch.rs
@@ -44,7 +44,10 @@ impl YawPitch {
 
     /// Initialize the yaw and pitch angles from a quaternion.
     /// Any roll rotation will be ignored.
-    pub fn rotation_quat(mut self, rotation: Quat) -> Self {
+    pub fn rotation_quat<Q>(mut self, rotation: Q) -> Self
+    where
+        Q: Into<mint::Quaternion<f32>>,
+    {
         self.set_rotation_quat(rotation);
         self
     }
@@ -69,7 +72,11 @@ impl YawPitch {
 
     /// Set the yaw and pitch angles from a quaternion.
     /// Any roll rotation will be ignored.
-    pub fn set_rotation_quat(&mut self, rotation: Quat) {
+    pub fn set_rotation_quat<Q>(&mut self, rotation: Q)
+    where
+        Q: Into<mint::Quaternion<f32>>,
+    {
+        let rotation: Quat = rotation.into().into();
         let (yaw, pitch, _) = rotation.to_euler(EulerRot::YXZ);
         self.yaw_degrees = yaw.to_degrees();
         self.pitch_degrees = pitch.to_degrees();
@@ -78,14 +85,16 @@ impl YawPitch {
 
 impl<H: Handedness> RigDriver<H> for YawPitch {
     fn update(&mut self, params: RigUpdateParams<H>) -> Transform<H> {
+        let rotation = Quat::from_euler(
+            EulerRot::YXZ,
+            self.yaw_degrees.to_radians(),
+            self.pitch_degrees.to_radians(),
+            0.0,
+        );
+
         Transform {
             position: params.parent.position,
-            rotation: Quat::from_euler(
-                EulerRot::YXZ,
-                self.yaw_degrees.to_radians(),
-                self.pitch_degrees.to_radians(),
-                0.0,
-            ),
+            rotation: rotation.into(),
             phantom: PhantomData,
         }
     }

--- a/src/handedness.rs
+++ b/src/handedness.rs
@@ -6,8 +6,14 @@ pub trait Handedness: Clone + Copy + Debug + 'static {
     const FORWARD_Z_SIGN: f32;
     const FORWARD: Vec3 = glam::vec3(0.0, 0.0, Self::FORWARD_Z_SIGN);
 
-    fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3;
-    fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3;
+    fn right_from_up_and_forward<V, U>(up: V, forward: V) -> U
+    where
+        V: Into<mint::Vector3<f32>>,
+        U: From<mint::Vector3<f32>>;
+    fn up_from_right_and_forward<V, U>(right: V, forward: V) -> U
+    where
+        V: Into<mint::Vector3<f32>>,
+        U: From<mint::Vector3<f32>>;
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -16,12 +22,28 @@ pub struct LeftHanded;
 impl Handedness for LeftHanded {
     const FORWARD_Z_SIGN: f32 = 1.0;
 
-    fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3 {
-        up.cross(forward)
+    fn right_from_up_and_forward<V, U>(up: V, forward: V) -> U
+    where
+        V: Into<mint::Vector3<f32>>,
+        U: From<mint::Vector3<f32>>,
+    {
+        let up: Vec3 = up.into().into();
+        let forward: Vec3 = forward.into().into();
+
+        let result = up.cross(forward);
+        From::from(result.into())
     }
 
-    fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3 {
-        forward.cross(right)
+    fn up_from_right_and_forward<V, U>(right: V, forward: V) -> U
+    where
+        V: Into<mint::Vector3<f32>>,
+        U: From<mint::Vector3<f32>>,
+    {
+        let right: Vec3 = right.into().into();
+        let forward: Vec3 = forward.into().into();
+
+        let result = forward.cross(right);
+        From::from(result.into())
     }
 }
 
@@ -31,11 +53,27 @@ pub struct RightHanded;
 impl Handedness for RightHanded {
     const FORWARD_Z_SIGN: f32 = -1.0;
 
-    fn right_from_up_and_forward(up: Vec3, forward: Vec3) -> Vec3 {
-        forward.cross(up)
+    fn right_from_up_and_forward<V, U>(up: V, forward: V) -> U
+    where
+        V: Into<mint::Vector3<f32>>,
+        U: From<mint::Vector3<f32>>,
+    {
+        let up: Vec3 = up.into().into();
+        let forward: Vec3 = forward.into().into();
+
+        let result = forward.cross(up);
+        From::from(result.into())
     }
 
-    fn up_from_right_and_forward(right: Vec3, forward: Vec3) -> Vec3 {
-        right.cross(forward)
+    fn up_from_right_and_forward<V, U>(right: V, forward: V) -> U
+    where
+        V: Into<mint::Vector3<f32>>,
+        U: From<mint::Vector3<f32>>,
+    {
+        let right: Vec3 = right.into().into();
+        let forward: Vec3 = forward.into().into();
+
+        let result = right.cross(forward);
+        From::from(result.into())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,5 +38,3 @@ pub mod prelude;
 pub mod rig;
 pub mod transform;
 pub mod util;
-
-pub use glam;

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -4,17 +4,24 @@ use std::marker::PhantomData;
 
 use crate::handedness::Handedness;
 
-/// A thin wrapper over a `Vec3` and a `Quat`
+/// A thin wrapper over a `Vector3<f32>` and a `Quaternion<f32>`
 #[derive(Clone, Copy, Debug)]
 pub struct Transform<H: Handedness> {
-    pub position: Vec3,
-    pub rotation: Quat,
+    pub position: mint::Vector3<f32>,
+    pub rotation: mint::Quaternion<f32>,
     pub phantom: PhantomData<H>,
 }
 
 impl<H: Handedness> Transform<H> {
     ///
-    pub fn from_position_rotation(position: Vec3, rotation: Quat) -> Self {
+    pub fn from_position_rotation<V, Q>(position: V, rotation: Q) -> Self
+    where
+        V: Into<mint::Vector3<f32>>,
+        Q: Into<mint::Quaternion<f32>>,
+    {
+        let position = position.into();
+        let rotation = rotation.into();
+
         Self {
             position,
             rotation,
@@ -23,29 +30,56 @@ impl<H: Handedness> Transform<H> {
     }
 
     ///
-    pub fn into_position_rotation(self) -> (Vec3, Quat) {
-        (self.position, self.rotation)
+    pub fn into_position_rotation<V, Q>(self) -> (V, Q)
+    where
+        V: From<mint::Vector3<f32>>,
+        Q: From<mint::Quaternion<f32>>,
+    {
+        (From::from(self.position), From::from(self.rotation))
     }
 
     /// +X
-    pub fn right(&self) -> Vec3 {
-        self.rotation * Vec3::X
+    pub fn right<V>(&self) -> V
+    where
+        V: From<mint::Vector3<f32>>,
+    {
+        let rotation: Quat = self.rotation.into();
+        From::from((rotation * Vec3::X).into())
     }
 
     /// +Y
-    pub fn up(&self) -> Vec3 {
-        self.rotation * Vec3::Y
+    pub fn up<V>(&self) -> V
+    where
+        V: From<mint::Vector3<f32>>,
+    {
+        let rotation: Quat = self.rotation.into();
+        From::from((rotation * Vec3::Y).into())
     }
 
     /// +/-Z
-    pub fn forward(&self) -> Vec3 {
-        self.rotation * H::FORWARD
+    pub fn forward<V>(&self) -> V
+    where
+        V: From<mint::Vector3<f32>>,
+    {
+        let rotation: Quat = self.rotation.into();
+        From::from((rotation * H::FORWARD).into())
     }
 
     ///
     pub const IDENTITY: Transform<H> = Transform {
-        position: Vec3::ZERO,
-        rotation: Quat::IDENTITY,
+        position: mint::Vector3 {
+            x: 0.0,
+            y: 0.0,
+            z: 0.0,
+        },
+        rotation: mint::Quaternion {
+            v: mint::Vector3 {
+                x: 0.0,
+                y: 0.0,
+                z: 0.0,
+            },
+            s: 1.0,
+        },
         phantom: PhantomData,
     };
 }

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -4,19 +4,19 @@ use std::marker::PhantomData;
 
 use crate::handedness::Handedness;
 
-/// A thin wrapper over a `Vector3<f32>` and a `Quaternion<f32>`
+/// A thin wrapper over a `Point3<f32>` and a `Quaternion<f32>`
 #[derive(Clone, Copy, Debug)]
 pub struct Transform<H: Handedness> {
-    pub position: mint::Vector3<f32>,
+    pub position: mint::Point3<f32>,
     pub rotation: mint::Quaternion<f32>,
     pub phantom: PhantomData<H>,
 }
 
 impl<H: Handedness> Transform<H> {
     ///
-    pub fn from_position_rotation<V, Q>(position: V, rotation: Q) -> Self
+    pub fn from_position_rotation<P, Q>(position: P, rotation: Q) -> Self
     where
-        V: Into<mint::Vector3<f32>>,
+        P: Into<mint::Point3<f32>>,
         Q: Into<mint::Quaternion<f32>>,
     {
         let position = position.into();
@@ -30,9 +30,9 @@ impl<H: Handedness> Transform<H> {
     }
 
     ///
-    pub fn into_position_rotation<V, Q>(self) -> (V, Q)
+    pub fn into_position_rotation<P, Q>(self) -> (P, Q)
     where
-        V: From<mint::Vector3<f32>>,
+        P: From<mint::Point3<f32>>,
         Q: From<mint::Quaternion<f32>>,
     {
         (From::from(self.position), From::from(self.rotation))
@@ -67,7 +67,7 @@ impl<H: Handedness> Transform<H> {
 
     ///
     pub const IDENTITY: Transform<H> = Transform {
-        position: mint::Vector3 {
+        position: mint::Point3 {
             x: 0.0,
             y: 0.0,
             z: 0.0,

--- a/src/util.rs
+++ b/src/util.rs
@@ -54,11 +54,18 @@ impl<T: Interpolate + Copy + std::fmt::Debug> ExpSmoothed<T> {
     }
 }
 
-pub fn look_at<H: Handedness>(forward: Vec3) -> Quat {
-    forward
+pub fn look_at<H: Handedness, V, Q>(forward: V) -> Q
+where
+    V: Into<mint::Vector3<f32>>,
+    Q: From<mint::Quaternion<f32>>,
+{
+    let forward: Vec3 = forward.into().into();
+
+    let result = forward
         .try_normalize()
         .and_then(|forward| {
-            let right = H::right_from_up_and_forward(Vec3::Y, forward).try_normalize()?;
+            let right =
+                H::right_from_up_and_forward::<Vec3, Vec3>(Vec3::Y, forward).try_normalize()?;
             let up = H::up_from_right_and_forward(right, forward);
             Some(Quat::from_mat3(&Mat3::from_cols(
                 right,
@@ -66,5 +73,7 @@ pub fn look_at<H: Handedness>(forward: Vec3) -> Quat {
                 forward * H::FORWARD_Z_SIGN,
             )))
         })
-        .unwrap_or_default()
+        .unwrap_or_default();
+
+    From::from(result.into())
 }


### PR DESCRIPTION
Implements https://github.com/h3r2tic/dolly/issues/16. It still leaves the conversion between types looking a bit messy in the examples. Happy to discuss and see if we can rework this. I _think_ it would be neater if macroquad exposed a similar `mint` feature.